### PR TITLE
Bug fixes: double quotes and wm_class for firefox

### DIFF
--- a/ignite
+++ b/ignite
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 
 function get_firefox_window {
-  dbus-send --session --dest=org.gnome.Shell --print-reply=literal /org/gnome/Shell/Extensions/Windows org.gnome.Shell.Extensions.Windows.List \
-    | jq --exit-status '[.[] | select ((.in_current_workspace == true) and (.wm_class | startswith("firefox") or endswith("firefox") ))] | first | .id'
+  dbus-send \
+    --session \
+    --dest=org.gnome.Shell \
+    --print-reply=literal \
+    /org/gnome/Shell/Extensions/Windows \
+    org.gnome.Shell.Extensions.Windows.List \
+    | jq --exit-status '
+      [
+        .[] | select (
+          (.in_current_workspace == true) and
+          (.wm_class | startswith("firefox") or endswith("firefox") )
+        )
+      ] | first | .id'
 }
 
 function raise_window {

--- a/ignite
+++ b/ignite
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 
 function get_firefox_window {
-  gdbus call \
-    --session \
-    --dest org.gnome.Shell \
-    --object-path /org/gnome/Shell/Extensions/Windows \
-    --method org.gnome.Shell.Extensions.Windows.List \
-    | sed "s/^('\(.*\)',)$/\1/" \
+  dbus-send --session --dest=org.gnome.Shell --print-reply=literal /org/gnome/Shell/Extensions/Windows org.gnome.Shell.Extensions.Windows.List \
     | jq --exit-status '[.[] | select ((.in_current_workspace == true) and (.wm_class | startswith("firefox")))] | first | .id'
 }
 

--- a/ignite
+++ b/ignite
@@ -2,7 +2,7 @@
 
 function get_firefox_window {
   dbus-send --session --dest=org.gnome.Shell --print-reply=literal /org/gnome/Shell/Extensions/Windows org.gnome.Shell.Extensions.Windows.List \
-    | jq --exit-status '[.[] | select ((.in_current_workspace == true) and (.wm_class | startswith("firefox")))] | first | .id'
+    | jq --exit-status '[.[] | select ((.in_current_workspace == true) and (.wm_class | startswith("firefox") or endswith("firefox") ))] | first | .id'
 }
 
 function raise_window {


### PR DESCRIPTION
There are two major bug fixes in this PR:

gdbus has a bug that caused "Windows Calls" extension generate invalid JSON when any window title contains double quote. (More detail on https://github.com/ickyicky/window-calls/issues/32)

As https://github.com/ickyicky/window-calls/issues/24 suggested, use `dbus-send` instead with `--print-reply=literal` can generate valid JSON.

---

The other one is, at least in my environment (Fedora 41, Firefox 133.0, x86_64), the wm_class shows `"org.mozilla.firefox"`. So `.wm_class | startswith("firefox")` wouldn't work.

I simply changed it to `.wm_class | startswith("firefox") or endswith("firefox")` and this works.
