### PR TITLE
fix: Windows app (via wine) have null wm_class

### DIFF
--- a/ignite
+++ b/ignite
@@ -11,7 +11,10 @@ function get_firefox_window {
       [
         .[] | select (
           (.in_current_workspace == true) and
-          (.wm_class | startswith("firefox") or endswith("firefox") )
+          (
+            (if .wm_class == null then "" else .wm_class end) |
+            startswith("firefox") or endswith("firefox")
+          )
         )
       ] | first | .id'
 }


### PR DESCRIPTION
I was running Windows applications (specifically MobaXterm) via Wine for testing other things and found out its wm_class is `null`, which causes jq to output `jq: error (at <stdin>:0): startswith() requires string inputs` error and starts a new Firefox window instead.

So the fix is simply to replace null with an empty string as a workaround before filtering wm_class across all windows.