### PR TITLE
Fix: Focus switching issue when prompted by Albert while using multiple windows.

### DIFF
--- a/ignite
+++ b/ignite
@@ -16,7 +16,7 @@ function get_firefox_window {
             startswith("firefox") or endswith("firefox")
           )
         )
-      ] | first | .id'
+      ] | sort_by(.last_focused_time) | reverse | first | .id'
 }
 
 function raise_window {
@@ -32,7 +32,7 @@ if WIN_ID="$(get_firefox_window)"; then
   raise_window "${WIN_ID}"
   firefox --new-tab "$@"
 else
-  nohup firefox --new-window "$@" > /dev/null 2>&1 &
+  nohup firefox --new-window --new-instance "$@" > /dev/null 2>&1 &
   sleep 0.5
   WIN_ID="$(get_firefox_window)"
   if [[ "${WIN_ID}" != "null" ]]; then


### PR DESCRIPTION
I'm happily using your script with Firefox and Albert.

By the way, when I'm using multiple Firefox windows, like splitting the screen with two browser windows, and I prompt Albert to open a Google link, it switches focus between them. For example, it opens one tab in window A, and the next time, in window B.

I changed the priority for selecting which Firefox window to open a new tab in, and now it works fine.
Thank you again for your code!